### PR TITLE
SOED9-110 - rebranched from lastest changes to avoid merge conflcts.

### DIFF
--- a/config/sync/migrate_plus.migration.soe_stanford_pages_d7_node.yml
+++ b/config/sync/migrate_plus.migration.soe_stanford_pages_d7_node.yml
@@ -1,0 +1,64 @@
+uuid: 095736e8-e35c-4867-a77b-d44c60b71f28
+langcode: en
+status: true
+dependencies: {  }
+id: soe_stanford_pages_d7_node
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: stanford_pages_d7
+label: 'SOE Stanford Pages Nodes'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: simple_xml
+  urls:
+    - 'https://engineering.stanford.edu/export/stanford-pages'
+  constants:
+    status: 1
+    type: stanford_page
+    basic_html: basic_html
+    minimal_html: minimal_html
+  ids:
+    nid:
+      type: string
+  item_selector: /nodes/node
+  fields:
+    -
+      name: nid
+      label: NID
+      selector: Nid
+    -
+      name: title
+      label: Title
+      selector: Title
+    -
+      name: body
+      label: Body
+      selector: Body
+process:
+  title: title
+  status: constants/status
+  type: constants/type
+  paragraph:
+    plugin: migration_lookup
+    migration: soe_stanford_pages_d7_paragraph_rows
+    source: nid
+  su_page_components/target_id:
+    plugin: extract
+    source: '@paragraph'
+    index:
+      - 0
+  su_page_components/target_revision_id:
+    plugin: extract
+    source: '@paragraph'
+    index:
+      - 1
+destination:
+  plugin: 'entity:node'
+  default_bundle: stanford_page
+migration_dependencies:
+  required:
+    - soe_stanford_pages_d7_paragraph_rows

--- a/config/sync/migrate_plus.migration.soe_stanford_pages_d7_node.yml
+++ b/config/sync/migrate_plus.migration.soe_stanford_pages_d7_node.yml
@@ -38,10 +38,18 @@ source:
       name: body
       label: Body
       selector: Body
+    -
+      name: path
+      label: Path
+      selector: Path
 process:
   title: title
   status: constants/status
   type: constants/type
+  path/pathauto:
+    plugin: default_value
+    default_value: 0
+  path/alias: path
   paragraph:
     plugin: migration_lookup
     migration: soe_stanford_pages_d7_paragraph_rows

--- a/config/sync/migrate_plus.migration.soe_stanford_pages_d7_paragraph_rows.yml
+++ b/config/sync/migrate_plus.migration.soe_stanford_pages_d7_paragraph_rows.yml
@@ -1,0 +1,58 @@
+uuid: a1c6947a-cb49-4e0e-ad5b-718de2da7210
+langcode: en
+status: true
+dependencies: {  }
+id: soe_stanford_pages_d7_paragraph_rows
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: stanford_pages_d7
+label: 'SOE Stanford Pages Paragraphs Rows'
+source:
+  constants:
+    text_format: stanford_html
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: simple_xml
+  urls:
+    - 'https://engineering.stanford.edu/export/stanford-pages'
+  ids:
+    nid:
+      type: string
+  item_selector: /nodes/node
+  fields:
+  fields:
+    -
+      name: nid
+      label: NID
+      selector: Nid
+    -
+      name: title
+      label: Title
+      selector: Title
+    -
+      name: body
+      label: Body
+      selector: Body
+process:
+  paragraph:
+    plugin: migration_lookup
+    migration: soe_stanford_pages_d7_paragraphs
+    source: nid
+  su_page_components/target_id:
+    plugin: extract
+    source: '@paragraph'
+    index:
+      - 0
+  su_page_components/target_revision_id:
+    plugin: extract
+    source: '@paragraph'
+    index:
+      - 1
+destination:
+  plugin: 'entity_reference_revisions:paragraph_row'
+  default_bundle: node_stanford_page_row
+migration_dependencies:
+  required:
+    - soe_stanford_pages_d7_paragraphs

--- a/config/sync/migrate_plus.migration.soe_stanford_pages_d7_paragraphs.yml
+++ b/config/sync/migrate_plus.migration.soe_stanford_pages_d7_paragraphs.yml
@@ -1,0 +1,39 @@
+uuid: 6f8139ab-56af-46f0-b1b0-dcbfe13f7bd5
+langcode: en
+status: true
+dependencies: {  }
+id: soe_stanford_pages_d7_paragraphs
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: stanford_pages_d7
+label: 'SOE Stanford Pages Paragraphs'
+source:
+  constants:
+    text_format: stanford_html
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: simple_xml
+  urls:
+    - 'https://engineering.stanford.edu/export/stanford-pages'
+  ids:
+    nid:
+      type: string
+  item_selector: /nodes/node
+  fields:
+    -
+      name: nid
+      label: NID
+      selector: Nid
+    -
+      name: body
+      label: body
+      selector: Body
+process:
+  su_wysiwyg_text/value: body
+  su_wysiwyg_text/format: constants/text_format
+destination:
+  plugin: 'entity_reference_revisions:paragraph'
+  default_bundle: stanford_wysiwyg
+migration_dependencies: {  }

--- a/config/sync/migrate_plus.migration_group.stanford_pages_d7.yml
+++ b/config/sync/migrate_plus.migration_group.stanford_pages_d7.yml
@@ -1,0 +1,10 @@
+uuid: 7b913bcf-0257-4e98-98dc-09cfab9a4a74
+langcode: en
+status: true
+dependencies: {  }
+id: stanford_pages_d7
+label: 'Stanford Pages D7'
+description: 'Used to import Stanford pages from the D7 site.'
+source_type: 'Drupal 7'
+module: null
+shared_configuration: null


### PR DESCRIPTION
#11  READY FOR REVIEW

# Summary
- The Stanford pages migration.

# Review By (Date)
- ASAP

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Urgency
- High

# Review Tasks


## Setup tasks and/or behavior to test

1. Check out this branch
2. Open the composer.json file and replace `dev-8.x-2.x` with `dev-SOED9-110`.
3. Run `composer update su-soe/engineering_profile`
4. Import config files. Should only be four of them. 
5. Run `drush cim -y`
6. Run `drush ms` to check for any errors. If errors appear, then try rebuilding the cache and run it again. If errors persist, let me know.
7. Finally run ` drush migrate:import --group=stanford_pages_d7` 
8. Open the site and got to /admin/content, and check for the new content. Which should mirror the XML file. https://engineering.stanford.edu/export/stanford-pages
9. Open as many pages as would give confidence that the body and titles came over correctly. 

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? 
   Yes.


# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOED9-110

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
