### PR TITLE
FIXUp - set site to no-follow.

### DIFF
--- a/config/sync/metatag.metatag_defaults.global.yml
+++ b/config/sync/metatag.metatag_defaults.global.yml
@@ -8,6 +8,7 @@ id: global
 label: Global
 tags:
   title: '[current-page:title] | [site:name]'
+  robots: 'noindex, nofollow'
   canonical_url: '[current-page:url]'
   og_url: '[current-page:url:absolute]'
   og_site_name: '[site:name]'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Sets all pages to 'no-follow, no-index' to alert search engines not to index. 

# Review By (Date)
ASAP

# Criticality
- 7

# Urgency
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Import
3. Check for `no-follow` in the headers.
