### PR TITLE
FIXUP - updating button link on related spotlight.

### DIFF
--- a/config/sync/views.view.spotlights.yml
+++ b/config/sync/views.view.spotlights.yml
@@ -1425,7 +1425,7 @@ display:
       use_more_always: false
       use_more_text: 'See more stories'
       link_display: custom_url
-      link_url: /spotlights
+      link_url: /spotlight
       title: 'Related spotlights'
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Problem: link at the bottom of "related spotlight" was pointed to the wrong path (/spotlights). This should fix it. 

# Review By (Date)
ASAP

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to any individual spotlight page. 
4. Verify the "see more stories" button goes to /spotlight (and not spotlights)
