### PR TITLE
SOEOPSFY24-124: Removed alterations to news path 

### DIFF
--- a/modules/engineering_profile_helper/modules/engineering_magazine/engineering_magazine.module
+++ b/modules/engineering_profile_helper/modules/engineering_magazine/engineering_magazine.module
@@ -43,18 +43,3 @@ function engineering_magazine_theme($existing, $type, $theme, $path) {
     ],
   ];
 }
-
-/**
- * Implements hook_pathauto_pattern_alter().
- */
-function engineering_magazine_pathauto_pattern_alter(PathautoPattern &$pattern, array $context) {
-  // If a story is marked as a magazine story, it needs to get a magazine path.
-  if ($context['bundle'] == 'stanford_news' &&
-    ($context['op'] == 'insert' || $context['op'] == 'update')) {
-
-    $node = $context['data']['node'];
-    if ($node->get('su_magazine_story')->value) {
-      $pattern->setPattern('magazine/[node:title]');
-    }
-  }
-}


### PR DESCRIPTION
Removed pathauto alter so that regular pathauto pattern applies

# Ready for Review

# Summary
- This removes the function that took news items specified as "magazine" and gave them a magazine path

# Review By (Date)
- Anytime

# Criticality
- Medium

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Make a new news item
3. Mark it as part of the magazine
4. Ensure it gets the path of /news/title

### Site Configuration Sync
None!

## Front End Validation
Only front-end impact is documented in https://stanfordits.atlassian.net/browse/SOEOPSFY24-123

## Backend / Functional Validation
### Code
N/A

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ NO] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ YES] Is the approach to the problem appropriate?

# Affected Projects or Products


# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOEOPSFY24-123
- https://stanfordits.atlassian.net/browse/SOEOPSFY24-5
- https://stanfordits.atlassian.net/browse/SOEOPSFY24-125

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
