### PR TITLE
SOEOPS-618 | add h1 to department taxonomy term pages

### DIFF
--- a/config/sync/core.entity_view_display.taxonomy_term.department.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.department.default.yml
@@ -34,7 +34,7 @@ third_party_settings:
                 label: hidden
                 settings: {  }
                 third_party_settings: {  }
-            weight: 0
+            weight: 1
             additional: {  }
           9be3cd57-4a98-4d1a-b05a-b5f35d054ed8:
             uuid: 9be3cd57-4a98-4d1a-b05a-b5f35d054ed8
@@ -47,7 +47,33 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
-            weight: 1
+            weight: 2
+            additional: {  }
+          97e44b7e-2eea-4900-8942-29bf33bc7632:
+            uuid: 97e44b7e-2eea-4900-8942-29bf33bc7632
+            region: content
+            configuration:
+              id: 'field_block:taxonomy_term:department:name'
+              label: Name
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: entity_title_heading
+                label: hidden
+                settings:
+                  tag: h1
+                third_party_settings:
+                  empty_fields:
+                    handler: ''
+                  field_formatter_class:
+                    class: visually-hidden
+                  field_label:
+                    label_value: ''
+                    label_tag: ''
+            weight: 0
             additional: {  }
         third_party_settings: {  }
   layout_library:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOEOPS-618 | add h1 to department taxonomy term pages (a11y issue)

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to `/news/department/bioengineering`
4. Verify that the h1 is visually hidden but appears in the dom
5. Review code 🕵️ 

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? **Yes**

# Associated Issues and/or People
- SOEOPS-618