### PR TITLE
SOEOPS-612 SOEOPS-615 | add magazine topics to news h3 card

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_news.stanford_h3_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.stanford_h3_card.yml
@@ -54,6 +54,7 @@ third_party_settings:
         - node_title
       news_topics:
         - su_news_topics
+        - su_soe_mag_topics
         - su_soe_external_source_text
       news_source:
         - su_news_source
@@ -62,7 +63,7 @@ third_party_settings:
     fields:
       'dynamic_token_field:node-news_content_url':
         plugin_id: 'dynamic_token_field:node-news_content_url'
-        weight: 5
+        weight: 6
         label: hidden
         formatter: default
       node_title:
@@ -114,7 +115,7 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 4
+    weight: 5
     region: news_source
   su_news_topics:
     type: entity_reference_list_label_class
@@ -148,6 +149,25 @@ content:
       field_label:
         label_value: ''
         label_tag: ''
+    weight: 4
+    region: news_topics
+  su_soe_mag_topics:
+    type: entity_reference_list_label_class
+    label: hidden
+    settings:
+      link: true
+      class: su-list-unstyled
+      list_type: ul
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+      ds:
+        ds_limit: ''
     weight: 3
     region: news_topics
 hidden:
@@ -170,4 +190,3 @@ hidden:
   su_shared_tags: true
   su_soe_department: true
   su_soe_mag_collection: true
-  su_soe_mag_topics: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOEOPS-612 SOEOPS-615 | add magazine topics to news h3 card

# Review By (Date)
- Thursday, 7/3

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to `/test-content-cjw`
4. Verify that the magazine topic appears for the Teaser and News List Paragraph content types
5. Review code

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? **Yes**


# Associated Issues and/or People
- SOEOPS-612
- SOEOPS-615