### PR TITLE
SOEOPS-646 | create temp lockup block with sr-only text

### DIFF
--- a/themes/engineering/templates/block/block--system-branding-block.html.twig
+++ b/themes/engineering/templates/block/block--system-branding-block.html.twig
@@ -1,0 +1,101 @@
+{#
+/**
+ * @file
+ * Available variables:
+ *
+ * site_logo: Logo for site as defined in Appearance or theme settings.
+ * site_name: Name for site as defined in Site information settings.
+ * site_slogan: Slogan for site as defined in Site information settings
+ * content: Containts the above vars with more information.
+ * lockup: Settings from the theme.
+ * use_logo: Setting from the theme
+ * configuration: More settings from the theme.
+ * - id: "system_branding_block"
+ * - label: "Site Branding"
+ * - use_site_logo: boolean
+ * - use_site_name: boolean
+ * - use_site_slogan: boolean
+ */
+#}
+
+{# Set some of the default options for the lockup. #}
+{% set attributes = attributes|without('class') %}
+{% set link = url('<front>') %}
+{% if lockup is not empty %}
+  {% set line3 = lockup.line3 %}
+  {% set line4 = lockup.line4 %}
+  {% set line5 = lockup.line5 %}
+{% endif %}
+
+{# The variant classes change when there is more than one line to render. #}
+{% if lockup.option is not empty %}
+  {% set modifier_class = "su-lockup--option-" ~ lockup.option %}
+{% endif %}
+
+{# Do not default the line 1 on variant O, S, or T #}
+{% if lockup.option != "o" and lockup.option != "s" and lockup.option != "t" %}
+  {% set line1 = content.site_name %}
+{% endif %}
+
+{# Grab the site1 variable if it is not empty #}
+{% if lockup.line1 is not empty %}
+ {% set line1 = lockup.line1 %}
+{% endif %}
+
+{# Default from the theme is to use the site slogan. #}
+{% set line2 = site_slogan %}
+{% if lockup.line2 is not empty %}
+ {% set line2 = lockup.line2 %}
+{% endif %}
+
+{# Enforce no lines on none. #}
+{% if lockup.option == 'none' %}
+  {% set line1 = '' %}
+  {% set line2 = '' %}
+  {% set line3 = '' %}
+  {% set line4 = '' %}
+  {% set line5 = '' %}
+{% endif %}
+
+{# If the theme has a custom logo. Use that. We can do this by overriding the twig block in lockup.twig #}
+{% block cell1 %}
+  {% if site_logo|render|striptags|trim is not empty and use_logo == false %}
+    <div class="su-lockup__logo-wrapper">
+      <img src="{{ site_logo }}" alt="" class="su-lockup__custom-logo" aria-hidden="true" />
+      <span class="sr-only">100 Stanford Engineering 1925–2025. A Century of Discovery, Innovation, and Impact</span>
+      {% if line4 is not empty %}
+        <span class="su-lockup__line4" {{ region_attributes.line4 }}>{{ line4 }}</span>
+      {% endif %}
+    </div>
+  {% else %}
+    <div class="su-lockup__wordmark-wrapper">
+      <span class="su-lockup__wordmark">Stanford</span>
+      {% if line4 is not empty %}
+        <span class="su-lockup__line4" {{ region_attributes.line4 }}>{{ line4 }}</span>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endblock %}
+
+{# Override block cell2 because we want to hide some elements if the none option is selected. #}
+{% block cell2 %}
+  {% if lockup.option != 'none' %}
+    {% if line1 is not empty or line2 is not empty or line3 is not empty %}
+    <div class="su-lockup__cell2">
+      {% if line1 is not empty %}
+      <span class="su-lockup__line1" {{ region_attributes.line1 }}>{{ line1 }}</span>
+      {% endif %}
+
+      {% if line2 is not empty %}
+      <span class="su-lockup__line2" {{ region_attributes.line2 }}>{{ line2 }}</span>
+      {% endif %}
+
+      {% if line3 is not empty %}
+      <span class="su-lockup__line3" {{ region_attributes.line3 }}>{{ line3 }}</span>
+      {% endif %}
+    </div>
+    {% endif %}
+  {% endif %}
+{% endblock %}
+
+{% extends "@decanter/components/lockup/lockup.twig" %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOEOPS-646 | create temp lockup block with sr-only text

# Review By (Date)
- Friday, Aug 1

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to homepage
4. Inspect lockup in nav and verify that screen reader text appears
5. Review code and determine if additional things should be removed from the template.

# Associated Issues and/or People
- SOEOPS-646