### PR TITLE
SOEOPS-654 | add close dropdown refocus state

### DIFF
--- a/modules/engineering_profile_helper/modules/engineering_magazine/dist/js/engineering_magazine.script.js
+++ b/modules/engineering_profile_helper/modules/engineering_magazine/dist/js/engineering_magazine.script.js
@@ -48,7 +48,7 @@ var __webpack_exports__ = {};
       $(document).on('keydown', function (e) {
         if (e.key === 'Escape' && isDropdownOpen) {
           closeTopicsDropdown();
-          toggleButton.focus();
+          focusOutsideDropdown();
         }
       });
 
@@ -61,6 +61,21 @@ var __webpack_exports__ = {};
         toggleButton.attr('aria-expanded', 'false');
         toggleButton.removeClass('soe-magazine__navigation-rotate-up');
         toggleButton.addClass('soe-magazine__navigation-rotate-down');
+      }
+      function focusOutsideDropdown() {
+        var mainNavItems = $('.news-navigation-bar a');
+        var topicsIndex = -1;
+        mainNavItems.each(function (index) {
+          if ($(this).closest('.topics_item').length || $(this).is('#magazine-landing-nav__topics-toggle')) {
+            topicsIndex = index;
+            return false;
+          }
+        });
+        if (topicsIndex !== -1 && topicsIndex < mainNavItems.length - 1) {
+          mainNavItems.eq(topicsIndex + 1).focus();
+        } else if (mainNavItems.length > 0) {
+          mainNavItems.first().focus();
+        }
       }
 
       // Enhanced keyboard navigation for topics dropdown
@@ -82,13 +97,15 @@ var __webpack_exports__ = {};
               case 'Tab':
                 // Handle tabbing out of dropdown
                 if (e.shiftKey && index === 0) {
+                  e.preventDefault();
                   setTimeout(function () {
                     closeTopicsDropdown();
-                    toggleButton.focus();
                   }, 0);
                 } else if (!e.shiftKey && index === topicLinks.length - 1) {
+                  e.preventDefault();
                   setTimeout(function () {
                     closeTopicsDropdown();
+                    focusOutsideDropdown();
                   }, 0);
                 }
                 break;

--- a/modules/engineering_profile_helper/modules/engineering_magazine/dist/js/engineering_magazine.script.js
+++ b/modules/engineering_profile_helper/modules/engineering_magazine/dist/js/engineering_magazine.script.js
@@ -100,6 +100,7 @@ var __webpack_exports__ = {};
                   e.preventDefault();
                   setTimeout(function () {
                     closeTopicsDropdown();
+                    toggleButton.focus();
                   }, 0);
                 } else if (!e.shiftKey && index === topicLinks.length - 1) {
                   e.preventDefault();

--- a/modules/engineering_profile_helper/modules/engineering_magazine/lib/js/magazine_navigation.js
+++ b/modules/engineering_profile_helper/modules/engineering_magazine/lib/js/magazine_navigation.js
@@ -109,7 +109,8 @@
                 if (e.shiftKey && index === 0) {
                   e.preventDefault();
                   setTimeout(() => {
-                  closeTopicsDropdown();
+                    closeTopicsDropdown();
+                    toggleButton.focus()
                   }, 0);
                 } else if (!e.shiftKey && index === topicLinks.length - 1) {
                   e.preventDefault();

--- a/modules/engineering_profile_helper/modules/engineering_magazine/lib/js/magazine_navigation.js
+++ b/modules/engineering_profile_helper/modules/engineering_magazine/lib/js/magazine_navigation.js
@@ -110,7 +110,7 @@
                   e.preventDefault();
                   setTimeout(() => {
                     closeTopicsDropdown();
-                    toggleButton.focus()
+                    toggleButton.focus();
                   }, 0);
                 } else if (!e.shiftKey && index === topicLinks.length - 1) {
                   e.preventDefault();

--- a/modules/engineering_profile_helper/modules/engineering_magazine/lib/js/magazine_navigation.js
+++ b/modules/engineering_profile_helper/modules/engineering_magazine/lib/js/magazine_navigation.js
@@ -53,7 +53,7 @@
       $(document).on('keydown', function (e) {
         if (e.key === 'Escape' && isDropdownOpen) {
           closeTopicsDropdown();
-          toggleButton.focus();
+          focusOutsideDropdown();
         }
       });
 
@@ -66,6 +66,23 @@
         toggleButton.attr('aria-expanded', 'false');
         toggleButton.removeClass('soe-magazine__navigation-rotate-up');
         toggleButton.addClass('soe-magazine__navigation-rotate-down');
+      }
+
+      function focusOutsideDropdown() {
+        const mainNavItems = $('.news-navigation-bar a');
+        let topicsIndex = -1;
+        mainNavItems.each(function(index) {
+          if ($(this).closest('.topics_item').length || $(this).is('#magazine-landing-nav__topics-toggle')) {
+            topicsIndex = index;
+            return false;
+          }
+        });
+
+        if (topicsIndex !== -1 && topicsIndex < mainNavItems.length - 1) {
+          mainNavItems.eq(topicsIndex + 1).focus();
+        } else if (mainNavItems.length > 0) {
+          mainNavItems.first().focus();
+        }
       }
 
       // Enhanced keyboard navigation for topics dropdown
@@ -90,13 +107,15 @@
               case 'Tab':
                 // Handle tabbing out of dropdown
                 if (e.shiftKey && index === 0) {
+                  e.preventDefault();
                   setTimeout(() => {
-                    closeTopicsDropdown();
-                    toggleButton.focus();
+                  closeTopicsDropdown();
                   }, 0);
                 } else if (!e.shiftKey && index === topicLinks.length - 1) {
+                  e.preventDefault();
                   setTimeout(() => {
                     closeTopicsDropdown();
+                    focusOutsideDropdown();
                   }, 0);
                 }
                 break;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOEOPS-654 | add close dropdown refocus state

# Review By (Date)
- Tuesday, Aug 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to `/news/topic/artificial-intelligence`
4. Tab through and toggle the Topic nav dropdown
5. Verify that you can tab right into the nav without having to tab through the other top level menu items
6. Verify that the active state appears for the topic page you are on
7. Decrease screen size and verify that mobile toggle still works as expected
8. Review code


# Associated Issues and/or People
- SOEOPS-654 